### PR TITLE
Add 'google-beta' provider for Use Case 1

### DIFF
--- a/Usecase 1/terraform/config.tf
+++ b/Usecase 1/terraform/config.tf
@@ -20,3 +20,10 @@ provider "google" {
   region      = var.default_region
   zone        = var.default_zone
 }
+
+provider "google-beta" {
+  credentials = file(var.credentials_path)
+  project     = var.project_id
+  region      = var.default_region
+  zone        = var.default_zone
+}


### PR DESCRIPTION
This PR adds the 'google-beta' provider for Use Case 1 Terraform scripts. 

The provider is used to create a CDF instance and may sometimes throw 403 errors if not present.